### PR TITLE
More celery tasks guidance

### DIFF
--- a/python.md
+++ b/python.md
@@ -830,6 +830,8 @@ prefer to define exception types in the same module as where they are raised.
 
 ### <a name="celery-tasks">Celery tasks</a>
 
+#### Task signatures
+
 Care is required when changing Celery task signatures as publishers and
 consumers get deployed at different times. It's important that changes to how an
 event is published don't cause consumers to crash.
@@ -860,8 +862,10 @@ Things to note:
    simplifies the future addition of arguments, as older workers can still handle newer
    tasks without crashing.
 
-These steps provide some robustness to signature changes but
-they are not watertight.
+#### Changing task signatures
+
+The pattern above provides some robustness to signature changes but
+it is not watertight.
 
 For frequently called tasks (that may be in-flight during a deployment), a
 two-phase approach is required (similar to how backwards-incompatible database

--- a/python.md
+++ b/python.md
@@ -906,7 +906,7 @@ def my_task(*, foo, **kwargs):
 The error handling above recognises that we should not treat an action already having been performed as a system error.
 Rather,
 it may have arisen because the task was executed twice, which we should expect to happen sometimes. However,
-following the principle of "Don't do nothing silently", we return a helpful message so that someone could see what
+following the principle of [Don't do nothing silently](#dont-do-nothing-silently), we return a helpful message so that someone could see what
 is happening if they need to debug this task.
 
 

--- a/python.md
+++ b/python.md
@@ -911,7 +911,7 @@ is happening if they need to debug this task.
 
 
 Avoid using the [``throws`` argument in a Celery task decorator](https://docs.celeryproject.org/en/stable/userguide/tasks.html#Task.throws),
-as this mark tasks as failed, but swallows the exception, preventing it from being sent to Sentry.
+as this marks tasks as failed, but swallows the exception, preventing it from being sent to Sentry.
 
 ### <a name="kwarg-only-functions">Keyword-only functions</a>
 


### PR DESCRIPTION
Following on from this slack thread about celery tasks: https://octoenergy.slack.com/archives/C0CBS8P2L/p1585237819113600

This is the outcome of what @fmarani and I ended up doing with adjusting the error handling in `octoenergy.interfaces.tasks.dunning.dunning_send_action_comm`.

I've avoided mentioning Loggly in the conventions as this is a public document, but here's a screenshot from a dashboard we made in Loggly. It shows a huge number of failed tasks, but a lot of them probably just aren't a problem. Better to have these tasks succeed, but include debugging data in the return value, if that's something we need to dig into. My argument is that it would be easier to build and interpret monitoring tools if we follow this convention - but I appreciate it's a matter of opinion.

![loggly-scheduled](https://user-images.githubusercontent.com/236623/78154821-9ed37100-7434-11ea-8836-95f39e443b04.png)
