### PR TITLE
Add spelling to general python conventions

### DIFF
--- a/python.md
+++ b/python.md
@@ -44,6 +44,7 @@ General Python:
 - [Application logic in interface layer](#application-logic-in-interface-layer)
 - [Don't do nothing silently](#dont-do-nothing-silently)
 - [Docstrings vs comments](#docstrings)
+- [Prefer American English for naming modules and objects](#naming-language)
 
 Testing:
 
@@ -1233,6 +1234,11 @@ Related reading:
 
 - http://stackoverflow.com/questions/19074745/python-docstrings-descriptions-vs-comments
 
+### <a name="naming-language">Prefer American English for naming modules and objects</a>
+
+When naming objects like modules, classes, functions and variables, prefer American English. Eg, use serializers.py instead of serialisers.py. This ensures the names in our codebase match those in the wider ecosystem.
+
+UK spellings are fine for in comments or docstrings.
 
 ## Testing
 


### PR DESCRIPTION
Prior to this change there were no conventions on spelling

This change adds a brief section outlining how we can make spelling more consistent. Spelling errors are fairly easy to pick up and often don't make it into production. The main purposes of this convention are:

a) to fractionally speed up development time by decreasing chances of initial mistakes.

b) to evidence that language choice has been thought about so a developer can offload the mental burden of any indecision.