### PR TITLE
Fix contradictory model method naming conventions in example

### DIFF
--- a/python.md
+++ b/python.md
@@ -189,11 +189,11 @@ class SomeModel(models.Model):
 
     # Mutators
 
-    def anonymise(self):
+    def set_anonymous(self):
         self.name = ''
         self.save()
 
-    def update_name(self, new_name):
+    def set_name(self, new_name):
         self.name = new_name
         self.save()
 
@@ -201,7 +201,6 @@ class SomeModel(models.Model):
 
     def get_num_apples(self):
         return self.fruits.filter(type="APPLE").count()
-
 
     # Properties
 


### PR DESCRIPTION
In `python.md`, `Model method naming conventions` states
"For query methods (ie methods that look something up and return it), prefix with get_.
For setter methods (ie methods that set fields and call save), prefix with set_."
However, an example in `Group methods and properties on models` does not use these conventions. This edit corrects the example.