### PR TITLE
Add a new convention not to add implicit ordering to models

### DIFF
--- a/conventions/django.md
+++ b/conventions/django.md
@@ -8,7 +8,7 @@
 - [Group methods and properties on models](#group-methods-and-properties-on-models)
 - [Create filter methods on querysets, not managers](#queryset-filters)
 - [Use `.get` when expecting exactly one result](#uniqueness)
-- [Don't rely on implicit ordering of querysets](#implicit-ordering)
+- [Don't rely on implicit ordering of querysets](#implicit-ordering-of-queries)
 - [Don't use audit fields for application logic](#audit-fields)
 - [Ensure `updated_at` is set when calling `QuerySet.update`](#update-updated-at)
 - [Be conservative with model `@property` methods](#property-methods)
@@ -245,7 +245,7 @@ except Thing.MultipleObjectsReturned:
 
 The second example avoids a race condition and is also more efficient, as only a single database query is required.
 
-## <a name="implicit-ordering">Don't rely on implicit ordering of querysets</a>
+## <a name="implicit-ordering-of-queries">Don't rely on implicit ordering of querysets</a>
 
 If you grab the `.first()` or `.last()` element of a queryset, ensure you
 explicitly sort it with `.order_by()`. Don't rely on the default ordering set

--- a/conventions/django.md
+++ b/conventions/django.md
@@ -8,6 +8,7 @@
 - [Group methods and properties on models](#group-methods-and-properties-on-models)
 - [Create filter methods on querysets, not managers](#queryset-filters)
 - [Use `.get` when expecting exactly one result](#uniqueness)
+- [Don't add implicit ordering to models](#implicit-ordering-in-models)
 - [Don't rely on implicit ordering of querysets](#implicit-ordering-of-queries)
 - [Don't use audit fields for application logic](#audit-fields)
 - [Ensure `updated_at` is set when calling `QuerySet.update`](#update-updated-at)
@@ -244,6 +245,25 @@ except Thing.MultipleObjectsReturned:
 ```
 
 The second example avoids a race condition and is also more efficient, as only a single database query is required.
+
+## <a name="implicit-ordering-in-models">Don't add implicit ordering to models</a>
+
+Django supports implicit ordering, where all queries to a model are ordered by one of
+their fields unless specified otherwise:
+
+```py
+class SomeModel(models.Model):
+    created_at = models.DateTimeField()
+    ...
+
+    class Meta:
+        ordering = ["created_at"]
+```
+
+Don't add implicit ordering to the `Meta` class of models. This can cause unnecessary
+database load, since developers who want to query your model might not require the
+results to be ordered, and might not realise that they are being ordered, since they
+didn't specify that themselves.
 
 ## <a name="implicit-ordering-of-queries">Don't rely on implicit ordering of querysets</a>
 

--- a/conventions/django.md
+++ b/conventions/django.md
@@ -269,8 +269,11 @@ didn't specify that themselves.
 
 If you grab the `.first()` or `.last()` element of a queryset, ensure you
 explicitly sort it with `.order_by()`. Don't rely on the default ordering set
-in the `Meta` class of the model as this may change later on breaking your
-assumptions.
+in the `Meta` class of the model as this may change later on, breaking your
+assumptions, and implicit ordering in general is against our conventions.
+
+Ordering should always be explicit. In general, favour ordering in Kraken's runtime
+rather than the DB's to further minimise load.
 
 When ordering querysets, ensure the fields you’re ordering by are covered by a
 uniqueness constraint. Without this, the ordering of queryset may be


### PR DESCRIPTION
A new convention is added not to add implicit ordering to models, justified by the unnecessary database load this can lead to.